### PR TITLE
Cancel a subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ The schema represents the relationships between the models in the database. The 
 
 | HTTP verbs | Paths  | Used for | Output |
 | ---------- | ------ | -------- | ------:|
-| POST | /api/v1/customers | Create a new customer | [json](#create-a-customer) |
-| POST | /api/v1/teas | Create a new tea | [json](#create-a-tea) |
-| POST | /api/v1/customers/:customer_id/subscriptions | Subscribe a Customer to a Tea | [json](#subscribe-a-customer-to-a-tea) |
-| PATCH | /api/v1/customers/:customer_id/subscriptions/:id | Cancel a customer's tea subscription | [json](#cancel-a-customer's-tea-subscription) |
-| GET | /api/v1/customers/:customer_id/subscriptions | Get all of a customer's subscriptions(active and cancelled) | [json](#get-all-subscription) |
-| ERROR | errors | Error handling for requests | [json](#error-handling) |
+| POST | /api/v1/customers | Create a new customer | [api_doc](https://github.com/klatour324/tea_subscription/blob/main/api_contract_doc.md#create-a-customer) |
+| POST | /api/v1/teas | Create a new tea | [json](https://github.com/klatour324/tea_subscription/blob/main/api_contract_doc.md#create-a-tea) |
+| POST | /api/v1/customers/:customer_id/subscriptions | Subscribe a Customer to a Tea | [api_doc](https://github.com/klatour324/tea_subscription/blob/main/api_contract_doc.md#subscribe-a-customer-to-a-tea) |
+| PATCH | /api/v1/customers/:customer_id/subscriptions/:id | Cancel a customer's tea subscription | [api_doc](https://github.com/klatour324/tea_subscription/blob/main/api_contract_doc.md#cancel-a-customer's-tea-subscription) |
+| GET | /api/v1/customers/:customer_id/subscriptions | Get all of a customer's subscriptions(active and cancelled) | [api_doc](https://github.com/klatour324/tea_subscription/blob/main/api_contract_doc.md#get-all-subscription) |
+| ERROR | errors | Error handling for requests | [api_doc](https://github.com/klatour324/tea_subscription/blob/main/api_contract_doc.md#error-handling) |
 
 
 ## Built With

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -8,9 +8,27 @@ class Api::V1::SubscriptionsController < ApplicationController
     end
   end
 
+  def update
+    return error("Invalid parameters: Active status is invalid. Please try again") if invalid_params?(params)
+    subscription = Subscription.find(params[:id])
+    if subscription.update(updated_subscription_params)
+      render json: SubscriptionSerializer.new(subscription), status: :ok
+    else
+      error(subscription.errors.full_messages.to_sentence)
+    end
+  end
+
   private
 
   def subscription_params
     params.permit(:title, :price, :frequency, :customer_id, :tea_id)
+  end
+
+  def updated_subscription_params
+    params.permit(:price, :frequency, :active)
+  end
+
+  def invalid_params?(params)
+    return true if params[:active].nil? || params[:id].nil?
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,11 @@
 class ApplicationController < ActionController::API
+  # rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
+
   def error(message = "Invalid request error. Please check the request.")
     render json: { error: message }, status: :bad_request
   end
+
+  # def record_not_found(exception)
+  #   render json: { error: exception.message }, status: :not_found
+  # end
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -5,4 +5,8 @@ class Subscription < ApplicationRecord
   validates_presence_of :title
   validates_presence_of :price
   validates_presence_of :frequency
+
+  def self.active(status)
+    where(active: status)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :customers, only: [:create] do
-        resources :subscriptions, only: [:create]
+        resources :subscriptions, only: [:create, :update]
       end
       resources :teas, only: [:create]
     end

--- a/spec/requests/api/v1/cancel_a_subscription_spec.rb
+++ b/spec/requests/api/v1/cancel_a_subscription_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+RSpec.describe 'Cancel a Customers Subscription' do
+  describe 'patch request to update active status to cancelled for a customers subscription' do
+    before :each do
+      @customer = Customer.create!(first_name: "Karen", last_name: "Koko",
+                                   email: "name@example.com", street_address: "123 Peppermint St.",
+                                   city: "Chicago", state: "IL", zipcode: "60601"
+                                  )
+      @tea = Tea.create!(title: "Honey Bear Tea", description: "Scrumptious Honeysuckle!", temperature: 202, brew_time: "7 minutes total")
+      @subscription = Subscription.create!(active: true, title: "One and Only Tea Subscription", price: 99.99, frequency: "Once in a lifetime", customer_id: @customer.id, tea_id: @tea.id)
+    end
+    describe 'happy path' do
+      it 'can update a subscription from active to cancelled' do
+        subscription_params = ({active: false})
+
+        headers = {"CONTENT_TYPE" => "application/json"}
+        patch "/api/v1/customers/#{@customer.id}/subscriptions/#{@subscription.id}", headers: headers, params: JSON.generate(subscription_params)
+
+        result = JSON.parse(response.body, symbolize_names: true)
+        subscription1 = Subscription.last
+
+        expect(response).to be_successful
+        expect(response.status).to eq(200)
+        expect(result).to be_a(Hash)
+        expect(result[:data]).to be_a(Hash)
+        expect(result[:data].count).to eq(3)
+        expect(result[:data]).to have_key(:id)
+        expect(result[:data][:id]).to be_a(String)
+        expect(result[:data][:id]).to eq(subscription1.id.to_s)
+        expect(result[:data]).to have_key(:type)
+        expect(result[:data][:type]).to eq("subscription")
+        expect(result[:data]).to have_key(:attributes)
+        expect(result[:data][:attributes]).to be_a(Hash)
+        expect(result[:data][:attributes].count).to eq(6)
+        expect(result[:data][:attributes]).to have_key(:title)
+        expect(result[:data][:attributes][:title]).to be_a(String)
+        expect(result[:data][:attributes]).to have_key(:customer_id)
+        expect(result[:data][:attributes][:customer_id]).to be_an(Integer)
+        expect(result[:data][:attributes]).to have_key(:tea_id)
+        expect(result[:data][:attributes][:tea_id]).to be_an(Integer)
+        expect(result[:data][:attributes]).to have_key(:active)
+        expect(result[:data][:attributes][:active]).to eq(false)
+        expect(result[:data][:attributes]).to have_key(:frequency)
+        expect(result[:data][:attributes][:frequency]).to be_a(String)
+        expect(result[:data][:attributes]).to have_key(:price)
+        expect(result[:data][:attributes][:price]).to be_a(Float)
+      end
+    end
+
+    describe 'sad path' do
+      it 'returns a 400 error response if a valid status is not provided' do
+        subscription_params = {active: nil}
+
+        headers = {"CONTENT_TYPE" => "application/json"}
+        patch "/api/v1/customers/#{@customer.id}/subscriptions/#{@subscription.id}", headers: headers, params: subscription_params.to_json
+
+        result = JSON.parse(response.body, symbolize_names: true)
+
+        expect(response).to_not be_successful
+        expect(response.status).to eq(400)
+        expect(result).to have_key(:error)
+        expect(result).to eq({error: "Invalid parameters: Active status is invalid. Please try again"})
+      end
+
+      # it 'returns a 404 error response if the subscription is invalid and does not exist' do
+      #   subscription_params = ({active: false, price: 49.99, frequency: "Four times a month"})
+      #   headers = {"CONTENT_TYPE" => "application/json"}
+      #   patch "/api/v1/customers/#{@customer.id}/subscriptions/1", headers: headers, params: JSON.generate(subscription_params)
+      #
+      #   result = JSON.parse(response.body, symbolize_names: true)
+      #
+      #   expect(response).to_not be_successful
+      #   expect(response.status).to eq(404)
+      #   expect(result).to have_key(:error)
+      #   expect(result).to eq({error: "Couldn't find Subscription with 'id'=1"})
+      # end
+    end
+  end
+end


### PR DESCRIPTION
### What Changed?
- Added the happy and initial sad path spec for updating/cancelling a subscription
- Updated routes for subscription with update action
- Created the update action in the subscription controller and implemented strong params for different error handling scenarios

### What's Next?
- Get all subscriptions for a customer (active and cancelled)
### Known Issues?
- Sad path 404 testing is not working quite as expected. Have it commented out to go over again
### Test Coverage?
- 99.5% 
### README & Documentation
- Refactored README to now point to api-contract-doc

closes #7 